### PR TITLE
ADC_LM35

### DIFF
--- a/Nhat Lam Nguyen
+++ b/Nhat Lam Nguyen
@@ -1,0 +1,48 @@
+/* Bai tap su dung ADC hien thi gia tri nhiet do LM35 qua led 7seg
+*/
+#define F_CPU 8000000UL
+#include <avr/interrupt.h>
+#include <avr/io.h>
+#include <util/delay.h>
+unsigned char maso[10] = {0xC0,0XF9,0XA4,0XB0,0X99,0X92,0X82,0XF8,0X80,0X90};
+unsigned char t;
+#define MODE_AREF 0xE0  // dinh nghia mode dien ap tham chieu on chip 2.56v MODE ADC 8bit
+
+
+unsigned char read_ADC()
+{
+	ADMUX = 0|MODE_AREF; // Chon kenh ADC0, dien ap tham chieu noi on chip
+	ADCSRA |= 0x40; // cho phep ADC start convert
+	while(!(ADCSRA&0x10)); // kiem tra bit ADIF
+	return ADCH;  // tra ve voi kenh 8 bit
+}
+void hienthi(unsigned char nhietdo)
+{
+	// ham quet led hien thi gia tri nhiet do
+	int a,b;
+	a = nhietdo/10; 
+	b = nhietdo%10;
+
+	PORTC  ^= (1<<3);
+	PORTD  = maso[a];
+	_delay_ms(2);
+	PORTC = 0XFF;
+
+	PORTC ^= (1<<4);
+	PORTD = maso[b];
+	_delay_ms(2);
+	PORTC = 0XFF;
+}
+int main()
+{
+	DDRC = 0XFF;
+	PORTC = 0XFF;
+	DDRD = 0XFF;
+	ADCSRA = 0X86; // bat ADEB ADPS2 ASPS1 fosc/64
+	ADMUX  = MODE_AREF;
+	while(1)
+	{	
+		t = read_ADC(); // lay gia tri ADC truyen vao ham hien thi
+		hienthi(t);
+	}
+}


### PR DESCRIPTION
Sử dụng cảm biến LM35 hiển thị giá trị nhiệt độ môi trường lên LED 7 thanh bằng ADC trên Atmega16
Creat_Nhat_Lam_Nguyen